### PR TITLE
adding reasonable default config for OpenMPI networking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,19 @@ RUN pip install --upgrade pip \
     && pip install mpi4py
 
 # ------------------------------------------------------------
+# Configure OpenMPI
+# ------------------------------------------------------------
+
+RUN mkdir -p ${HOME}/.openmpi \
+  && touch ${HOME}/.openmpi/mca-params.conf \
+  && tee -a /home/mpirun/.openmpi/mca-params.conf <<EOF \
+    btl=tcp,self \
+    btl_tcp_if_include=eth0 \
+    plm_rsh_no_tree_spawn=1 \
+    EOF \
+  && chown ${USER}:${USER} ${HOME}/.openmpi
+
+# ------------------------------------------------------------
 # Copy MPI4PY example scripts
 # ------------------------------------------------------------
 


### PR DESCRIPTION
Without the following config, I sometimes have trouble getting OpenMPI to run. This assumes eth0 is the interface to be used (somehow, OpenMPI seems to need this to be specified in some environments); I guess this could be made an ARG parameter in the Dockerfile to highlight that it is configurable, or perhaps specified at container creation by some means?