### PR TITLE
Fix formatting and spelling in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,13 +43,13 @@ $> docker-compose scale mpi_head=1 mpi_node=3
 Once all containers are running, you can login into the `mpi_head` node and start MPI jobs with `mpirun`. Alternatively, you can execute a one-shot command on that container with the `docker-compose exec` syntax, as follows: 
 
     docker-compose exec --user mpirun --privileged mpi_head mpirun -n 2 python /home/mpirun/mpi4py_benchmarks/all_tests.py
-    ----------------------------------------- ----------- --------------------------------------------------
-    1.                                        2.          3.
+    ------------------------------------------------------- ----------- --------------------------------------------------
+    1.                                                      2.          3.
 
 Breaking the above command down:
 
-1. Execute command on node `mpi-head`
-2. run on 2 MPI ranks
+1. Execute command on node `mpi_head`
+2. Run on 2 MPI ranks
 3. Command to run (NB: the Python script needs to import MPI bindings)
 
 ## Testing


### PR DESCRIPTION
1. Fix example formatting (underline) - was broken in commit 6cb62e5262268232a07743fb006ce46602cd7dc7
2. Fix `mpi_head` spelling
3. Fix list item capitalization